### PR TITLE
build/SCRUM-72: Secure Docker Compose Architecture & Reverse Proxy Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ backend/*.sqlite3-journal
 
 # Docker
 .docker-sync/
-docker-compose.override.yml
 
 # NPM
 npm-data/

--- a/.gitignore
+++ b/.gitignore
@@ -13,14 +13,10 @@ backend/.bundle/
 backend/*.sqlite3
 backend/*.sqlite3-journal
 
-# Frontend (Vue.js)
-frontend/node_modules/
-frontend/dist/
-frontend/npm-debug.log*
-frontend/yarn-debug.log*
-frontend/yarn-error.log*
-
 # Docker
 .docker-sync/
 docker-compose.override.yml
 
+# NPM
+npm-data/
+npm-letsencrypt/

--- a/backend/app.rb
+++ b/backend/app.rb
@@ -2,6 +2,9 @@ require 'sinatra'
 require 'sequel'
 require_relative 'config/environment.rb'
 
+set :host_authorization, { permitted_hosts: ['vmd166389.contaboserver.net', 'localhost', '127.0.0.1'] }
+
+
 # --- Routes ---
 set :views, File.join(File.dirname(__FILE__), 'frontend', 'views')
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,9 @@
+services:
+  db:
+    ports:
+      - "6543:5432"  # DB lokal erreichbar
+
+  backend:
+    ports:
+      - "4567:4567"  # Backend lokal erreichbar
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,13 +7,11 @@ services:
       POSTGRES_DB: licentra_development
     volumes:
       - postgres_data:/var/lib/postgresql/data
-    ports:
-      - "6543:5432"
+    networks:
+      - backend-net
 
   backend:
     build: ./backend
-    ports:
-      - "4567:4567"
     depends_on:
       - db
     environment:
@@ -24,19 +22,28 @@ services:
     volumes:
       - ./backend:/app
       - ./frontend:/app/frontend
+    networks:
+      - backend-net
+      - proxy-net
 
   nginx-proxy-manager:
     image: jc21/nginx-proxy-manager:latest
     restart: unless-stopped
     profiles: ["proxy"]
     ports:
-      - "80:80"    # HTTP
-      - "443:443"  # HTTPS
-      - "81:81"    # Admin-UI
+      - "80:80"
+      - "443:443"
+      - "81:81"
     volumes:
       - ./npm-data:/data
       - ./npm-letsencrypt:/etc/letsencrypt
+    networks:
+      - proxy-net
 
 volumes:
   postgres_data:
+
+networks:
+  backend-net:
+  proxy-net:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,5 +25,18 @@ services:
       - ./backend:/app
       - ./frontend:/app/frontend
 
+  nginx-proxy-manager:
+    image: jc21/nginx-proxy-manager:latest
+    restart: unless-stopped
+    profiles: ["proxy"]
+    ports:
+      - "80:80"    # HTTP
+      - "443:443"  # HTTPS
+      - "81:81"    # Admin-UI
+    volumes:
+      - ./npm-data:/data
+      - ./npm-letsencrypt:/etc/letsencrypt
+
 volumes:
   postgres_data:
+


### PR DESCRIPTION
### Summary

This PR implements a more secure Docker Compose setup for the Licentra application by restricting backend and database services to internal Docker networks and exposing only the reverse proxy (nginx-proxy-manager) externally. It also prepares the deployment for production use.

---

### Details

- **Docker Compose**
  - Removed host port bindings for backend and database services to prevent direct external access.
  - Added custom internal Docker networks for service isolation.
  - Only the reverse proxy (`nginx-proxy-manager`) is exposed externally on ports 80, 81, and 443.
  - Backend and database are now only accessible within the Docker networks.
  - Added a Compose override for easier access during development.

- **Reverse Proxy & Deployment**
  - Integrated `nginx-proxy-manager` as the reverse proxy for production deployment.
  - Updated `.gitignore` to exclude nginx-proxy-manager data directories (`npm-data`, `npm-letsencrypt`).
  - Configured Sinatra `host_authorization` for server hostname security.
  - Note: The DNS A record for `licentra.de` has been set at the provider, but propagation is still pending. SSL certificate via Let's Encrypt will be enabled in the Nginx Proxy Manager UI once DNS propagation is complete.

- **Security**
  - The server firewall remains active, so only the necessary ports are accessible in production.

---

### Notes for Reviewers

- Please review the Docker Compose networking configuration and ensure that only the intended services are exposed externally.
- These changes are optimized for production but can be flexibly used in development via the override.
- Full HTTPS functionality (as required by SCRUM-72) will be enabled once DNS propagation is complete and the SSL certificate is issued in the Nginx Proxy Manager UI.
- This PR is merged now to avoid rebase issues with ongoing backend Docker Compose changes.

