### PR TITLE
Introduce Manual Deployment Workflow via GitHub Actions (SCRUM-96)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,52 @@
+name: Manual Deploy with Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to deploy"
+        required: true
+        default: "main"
+
+jobs:
+  test:
+    name: Run Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run backend tests
+        run: docker-compose run --rm backend bundle exec rake spec
+        env:
+          RACK_ENV: test
+
+  deploy:
+    name: Deploy to Production Server
+    runs-on: ubuntu-latest
+    needs: test
+
+    if: github.event_name == 'workflow_dispatch'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Deploy to Server via SSH
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USERNAME }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            cd /opt/Licentra
+
+            git checkout ${{ github.event.inputs.branch }}
+            git pull origin ${{ github.event.inputs.branch }}
+
+            docker-compose -f docker-compose.yml pull
+
+            docker-compose -f docker-compose.yml --profile proxy up -d --build --force-recreate
+
+            docker image prune -f


### PR DESCRIPTION
**Related Issue:** SCRUM-96

**Description:**
This pull request adds a new GitHub Actions workflow to enable manual deployment of the application to the production server. This provides a controlled way to push updates when ready.

**Key Changes:**
*   Created `.github/workflows/deploy.yml` defining the new pipeline.
*   Configured the workflow to be triggered manually using `workflow_dispatch`.
*   Added a `test` job that runs the unit test suite (`docker-compose run --rm backend bundle exec rake spec` within the container) as a prerequisite. Deployment only proceeds if tests pass.
*   Implemented a `deploy` job that:
    *   Connects to the production server using SSH (requires secrets like `SSH_PRIVATE_KEY`, `SSH_USER`, `SSH_HOST`).
    *   Navigates to the project directory.
    *   Pulls the latest code from the specified branch.
    *   Restarts the application using `docker-compose -f docker-compose.yml --profile proxy up -d --build --force-recreate`.

**How to Review:**
*   Verify the workflow logic in `.github/workflows/deploy.yml`.
*   Ensure correct usage of secrets for sensitive data (SSH keys, host, user).
*   Confirm the test command is appropriate for our setup.

**Notes:**
*   Necessary secrets must be configured in the repository/organization settings for this workflow to function.