### PR TITLE
ci(backend): Fix docker compose command and add prod config [SCRUM-96]

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run backend tests
-        run: docker-compose run --rm backend bundle exec rake spec
+        run: docker compose run --rm backend bundle exec rake spec
         env:
           RACK_ENV: test
 
@@ -45,8 +45,8 @@ jobs:
             git checkout ${{ github.event.inputs.branch }}
             git pull origin ${{ github.event.inputs.branch }}
 
-            docker-compose -f docker-compose.yml pull
+            docker compose -f docker-compose.yml pull
 
-            docker-compose -f docker-compose.yml --profile proxy up -d --build --force-recreate
+            docker compose -f docker-compose.yml -f docker-compose.prod.yml --profile proxy up -d --build --force-recreate
 
             docker image prune -f


### PR DESCRIPTION
*   Removed the hyphen from the `docker-compose` command (now `docker compose`).
*   Added the `-f docker-compose.prod.yml` file to the relevant `docker compose` command in the CI pipeline.

This ensures the correct syntax is used and the production configuration is active during deployment on the server.

Fixes SCRUM-96