### PR TITLE
feat(SCRUM-58,SCRUM-59): Add and Update products as an admin

### DIFF
--- a/backend/app.rb
+++ b/backend/app.rb
@@ -12,6 +12,7 @@ Dir.glob('./services/*.rb').sort.each { |file| require file }
 Dir.glob('./routes/*.rb').sort.each { |file| require file }
 
 class LicentraApp < Sinatra::Base
+  enable :method_override
   enable :sessions
   set :session_secret, ENV.fetch('SESSION_SECRET') { SecureRandom.hex(64) }
   set :views, File.join(File.dirname(__FILE__), 'frontend', 'views')

--- a/backend/routes/admin_routes.rb
+++ b/backend/routes/admin_routes.rb
@@ -24,7 +24,29 @@ module AdminRoutes
 
     app.get '/product_management' do
       require_role('Admin')
+      @products = ProductDAO.all
       erb :product_management
+    end
+
+    app.post '/product_management' do
+      require_role('Admin')
+      product_name = params[:product_name]
+
+      # Neues Produkt anlegen
+      begin
+        product = Product.new(product_name: product_name)
+        if product.valid?
+          product.save_changes
+          status 201
+          body 'Product created successfully'
+        else
+          status 422
+          body product.errors.full_messages.join(', ')
+        end
+      rescue => e
+        status 500
+        body "Error creating product: #{e.message}"
+      end
     end
 
     app.get '/license_management' do

--- a/backend/routes/admin_routes.rb
+++ b/backend/routes/admin_routes.rb
@@ -49,6 +49,27 @@ module AdminRoutes
       end
     end
 
+    app.put '/product_management/:id' do
+      require_role('Admin')
+      product_id = params[:id]
+      product_name = params[:product_name]
+
+      begin
+        # Produkt aktualisieren
+        result = ProductDAO.update(product_id, product_name: product_name)
+        if result
+          status 200
+          body 'Product updated successfully'
+        else
+          status 422
+          body 'Product could not be updated'
+        end
+      rescue => e
+        status 500
+        body "Error updating product: #{e.message}"
+      end
+    end
+
     app.get '/license_management' do
       require_role('Admin')
       erb :license_management

--- a/backend/routes/admin_routes.rb
+++ b/backend/routes/admin_routes.rb
@@ -55,15 +55,13 @@ module AdminRoutes
       product_name = params[:product_name]
 
       begin
-        # Produkt aktualisieren
         result = ProductDAO.update(product_id, product_name: product_name)
-        if result
-          status 200
-          body 'Product updated successfully'
-        else
-          status 422
-          body 'Product could not be updated'
-        end
+        status 200
+        body 'Product updated successfully'
+      rescue DAO::ValidationError => e
+        status 422
+        error_messages = e.respond_to?(:errors) ? e.errors.full_messages.join(',') : e.message
+        body error_messages
       rescue => e
         status 500
         body "Error updating product: #{e.message}"

--- a/backend/spec/routes/product_management_spec.rb
+++ b/backend/spec/routes/product_management_spec.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rack/test'
+require_relative '../../app'
+
+RSpec.describe 'Product Management' do
+  include Rack::Test::Methods
+
+  def app
+    LicentraApp.new
+  end
+
+  def session
+    last_request.env['rack.session']
+  end
+
+  # --- Test Data Setup using Fabricators ---
+  let!(:admin_role) { Fabricate(:role, role_name: 'Admin') }
+  let!(:user_role)  { Fabricate(:role, role_name: 'User') }
+
+  let!(:admin_user) do
+    user = Fabricate(:user,
+                     username: 'admin_test',
+                     email: 'admin_test@example.com',
+                     first_name: 'Admin',
+                     last_name: 'Test',
+                     is_active: true)
+    Fabricate(:user_credential, user: user, password: 'password123')
+    user.add_role(admin_role)
+    user.add_role(user_role)
+    user.refresh
+    user
+  end
+
+  # Helper-Methode zum Einloggen als Admin
+  def login_as_admin
+    post '/login', { email: admin_user.email, password: 'password123' }
+    follow_redirect! while last_response.redirect?
+  end
+
+  # Helper-Methode zum Erstellen eines Produkts
+  def create_product(name)
+    post '/product_management', { product_name: name }
+  end
+
+  # Helper-Methode zum Aktualisieren eines Produkts
+  def update_product(id, name)
+    put "/product_management/#{id}", { product_name: name }
+  end
+
+  before(:each) do
+    # Datenbank für jeden Test zurücksetzen
+    Product.dataset.delete
+    login_as_admin
+  end
+
+  describe 'GET /product_management' do
+    it 'zeigt die Produktverwaltungsseite an' do
+      get '/product_management'
+      expect(last_response).to be_ok
+      expect(last_response.body).to include('Product Management')
+    end
+
+    it 'verweigert Zugriff für nicht-authentifizierte Benutzer' do
+      # Ausloggen
+      get '/logout'
+      expect(last_response).to be_redirect
+      
+      # Versuch, auf die Produktverwaltung zuzugreifen
+      get '/product_management'
+      expect(last_response).to be_redirect
+      expect(last_response.location).to include('/login')
+    end
+
+    it 'zeigt alle vorhandenen Produkte an' do
+      # Produkte erstellen
+      ProductDAO.create(product_name: 'Test Product 1')
+      ProductDAO.create(product_name: 'Test Product 2')
+      
+      get '/product_management'
+      expect(last_response).to be_ok
+      expect(last_response.body).to include('Test Product 1')
+      expect(last_response.body).to include('Test Product 2')
+    end
+  end
+
+  describe 'POST /product_management' do
+    it 'erstellt ein neues Produkt' do
+      create_product('New Product')
+      expect(last_response.status).to eq(201)
+      
+      # Überprüfen, ob das Produkt in der Datenbank existiert
+      product = Product.first(product_name: 'New Product')
+      expect(product).not_to be_nil
+    end
+
+    it 'verhindert die Erstellung von Produkten mit doppeltem Namen' do
+      # Erstes Produkt erstellen
+      create_product('Duplicate Product')
+      expect(last_response.status).to eq(201)
+      
+      # Versuch, ein Produkt mit demselben Namen zu erstellen
+      create_product('Duplicate Product')
+      expect(last_response.status).to eq(422)
+      expect(last_response.body).to include('already taken')
+    end
+  end
+
+  describe 'PUT /product_management/:id' do
+    it 'aktualisiert ein bestehendes Produkt' do
+      # Produkt erstellen
+      product = ProductDAO.create(product_name: 'Original Name')
+      
+      # Produkt aktualisieren
+      update_product(product.product_id, 'Updated Name')
+      expect(last_response.status).to eq(200)
+      
+      # Überprüfen, ob der Name aktualisiert wurde
+      updated_product = Product.first(product_id: product.product_id)
+      expect(updated_product.product_name).to eq('Updated Name')
+    end
+
+    it 'verhindert die Aktualisierung zu einem bereits verwendeten Namen' do
+      # Zwei Produkte erstellen
+      product1 = ProductDAO.create(product_name: 'Product One')
+      product2 = ProductDAO.create(product_name: 'Product Two')
+      
+      # Versuch, product2 auf denselben Namen wie product1 zu aktualisieren
+      update_product(product2.product_id, 'Product One')
+      expect(last_response.status).to eq(422)
+      expect(last_response.body).to include('already taken')
+    end
+
+    it 'gibt einen Fehler zurück, wenn das Produkt nicht existiert' do
+      update_product(999, 'Nonexistent Product')
+      expect(last_response.status).to eq(500)
+      expect(last_response.body).to include('Error updating product')
+    end
+  end
+
+  describe 'Zugriffskontrolle für nicht-Admin-Benutzer' do
+    let!(:regular_user) do
+      user = Fabricate(:user,
+                       username: 'user_test',
+                       email: 'user_test@example.com',
+                       first_name: 'User',
+                       last_name: 'Test',
+                       is_active: true)
+      Fabricate(:user_credential, user: user, password: 'password123')
+      user.add_role(user_role)
+      user.refresh
+      user
+    end
+
+    def login_as_regular_user
+      post '/login', { email: regular_user.email, password: 'password123' }
+      follow_redirect! while last_response.redirect?
+    end
+
+    it 'verweigert normalen Benutzern den Zugriff auf die Produktverwaltung' do
+      # Ausloggen und als normaler Benutzer einloggen
+      get '/logout'
+      login_as_regular_user
+      
+      # Versuche, auf die Produktverwaltung zuzugreifen
+      get '/product_management'
+      expect(last_response.status).to eq(403) # Forbidden
+    end
+
+    it 'verweigert normalen Benutzern das Erstellen von Produkten' do
+      # Ausloggen und als normaler Benutzer einloggen
+      get '/logout'
+      login_as_regular_user
+      
+      # Versuche, ein Produkt zu erstellen
+      create_product('Regular User Product')
+      expect(last_response.status).to eq(403) # Forbidden
+    end
+
+    it 'verweigert normalen Benutzern das Aktualisieren von Produkten' do
+      # Als Admin ein Produkt erstellen
+      get '/logout'
+      login_as_admin
+      product = ProductDAO.create(product_name: 'Admin Product')
+      
+      # Ausloggen und als normaler Benutzer einloggen
+      get '/logout'
+      login_as_regular_user
+      
+      # Versuche, das Produkt zu aktualisieren
+      update_product(product.product_id, 'Updated by Regular User')
+      expect(last_response.status).to eq(403) # Forbidden
+    end
+  end
+end
+

--- a/frontend/views/product_management.erb
+++ b/frontend/views/product_management.erb
@@ -154,74 +154,66 @@ document.addEventListener("DOMContentLoaded", () => {
   form.addEventListener("submit", e => {
     e.preventDefault();
     
-    // Nur beim Speichern eines neuen Produkts
-    if (title.textContent.includes('Add new Product')) {
-      fetch('/product_management', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-        body: new URLSearchParams({
-          'product_name': form.product_name.value
-        })
-      })
-      .then(response => {
-        if (response.ok) {
-          // Seite neu laden, um das neue Produkt anzuzeigen
-          window.location.reload();
-        } else {
-          return response.text().then(errorText => {
-            const errorMessage = errorText.includes('Validation failed')
-              ? 'Der Produktname wird bereits verwendet. Bitte wähle einen anderen Namen.'
-              : 'Fehler beim Aktualisieren des Produkts: ' + errorText;
+    // Ziel-URL und Methode bestimmen
+    let url = '/product_management';
+    let method = 'POST';
+    let bodyParams = { 'product_name': form.product_name.value };
 
-            showErrorNotification(errorMessage);
-          });
-        }
-      })
-      .catch(error => {
-        alert('Fehler: ' + error);
-      });
-    } else {
-      // Update eines bestehenden Produkts
-      const productName = form.product_name.value;
+    if (!title.textContent.includes('Add new Product')) {
+      // Update-Fall
       const productId = document.querySelector('.product-item.active')?.dataset.product_id;
       if (!productId || productId === 'undefined') {
-        alert('Fehler: Produkt-ID konnte nicht ermittelt werden');
+        showErrorNotification('Fehler: Produkt-ID konnte nicht ermittelt werden'); // Besser als alert
         return;
       }
-      
-      fetch(`/product_management/${productId}`, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-        body: new URLSearchParams({
-          'product_name': productName
-        })
-      })
-      .then(response => {
-        if (response.ok) {
-          window.location.reload();
-        } else {
-          return response.text().then(errorText => {
-            // Fehlermeldung in einem benutzerfreundlichen Format anzeigen
-            const errorMessage = errorText.includes('Validation failed')
-              ? 'Der Produktname wird bereits verwendet. Bitte wähle einen anderen Namen.'
-              : 'Fehler beim Aktualisieren des Produkts: ' + errorText;
-
-            // Elegantere Anzeige statt alert
-            showErrorNotification(errorMessage);
-          });
-        }
-      })
-      .catch(error => {
-        alert('Fehler: ' + error);
-      });
+      url = `/product_management/${productId}`;
+      method = 'PUT';
     }
-    
-    modal.classList.add("hidden");
+
+    // Fetch-Aufruf
+    fetch(url, {
+      method: method,
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams(bodyParams)
+    })
+    .then(response => {
+      if (response.ok) {
+        // === ERFOLGSFALL ===
+        modal.classList.add("hidden"); // Modal NUR bei Erfolg schließen
+        window.location.reload(); // Seite neu laden
+      } else {
+        // === FEHLERFALL (z.B. 422 Validation Error) ===
+        return response.text().then(errorText => {
+          // Fehlermeldung bestimmen
+          const errorMessage = errorText.includes('already taken') // Prüft auf die spezifische Fehlermeldung
+            ? 'Der Produktname wird bereits verwendet. Bitte wähle einen anderen Namen.'
+            : `Fehler beim ${method === 'POST' ? 'Erstellen' : 'Aktualisieren'} des Produkts: ${errorText}`;
+          
+          // Benachrichtigung anzeigen (Modal bleibt offen)
+          showErrorNotification(errorMessage);
+
+          // Optional: Sicherstellen, dass der Edit-Modus aktiv bleibt, falls es ein Update war
+          if (method === 'PUT') {
+             isEditMode = true; // Erzwinge Edit-Mode, falls er durch Klicks o.ä. verloren ging
+             editBtn.textContent = "Abbrechen";
+             editBtn.classList.add("cancel-btn");
+             saveBtn.disabled = false; 
+             // Felder bleiben entsperrt, da der Fehler im Edit-Modus auftrat
+          }
+        });
+      }
+    })
+    .catch(error => {
+      // Netzwerkfehler etc.
+      showErrorNotification('Netzwerkfehler oder anderer Fehler: ' + error.message);
+      // Modal bleibt ebenfalls offen, damit der Benutzer es erneut versuchen kann
+    });
+
+    // modal.classList.add("hidden"); // <-- DIESE ZEILE WIRD HIER ENTFERNT!
   });
+
 });
 
 function showErrorNotification(message) {

--- a/frontend/views/product_management.erb
+++ b/frontend/views/product_management.erb
@@ -12,15 +12,11 @@
   </div>
 
   <ul class="product-list">
-    <% products = [
-      { name: "ProX 200",     license_count: 3 },
-      { name: "Alpha Gadget", license_count: 1 }
-    ] %>
-    <% products.each do |p| %>
+    <% @products.each do |p| %>
       <li class="product-item"
-          data-product_name="<%= p[:name] %>"
-          data-license_count="<%= p[:license_count] %>">
-        <span class="product-name"><%= p[:name] %></span>
+          data-product_name="<%= p.product_name %>"
+          data-license_count="<%= p.licenses.count %>">
+        <span class="product-name"><%= p.product_name %></span>
       </li>
     <% end %>
   </ul>
@@ -70,9 +66,9 @@ document.addEventListener("DOMContentLoaded", () => {
     // Inputs sperren
     [...form.elements].forEach(el => {
       if (['edit-btn','save-btn','delete-btn'].includes(el.id)) return;
-      el.disabled = true;
+      el.disabled = mode === 'edit'; // Bei 'add' nicht sperren
     });
-    saveBtn.disabled = true;
+    saveBtn.disabled = mode === 'edit';
     deleteBtn.style.display = mode === 'edit' ? 'inline-block' : 'none';
     modal.classList.remove("hidden");
   }
@@ -106,7 +102,35 @@ document.addEventListener("DOMContentLoaded", () => {
 
   form.addEventListener("submit", e => {
     e.preventDefault();
+    
+    // Nur beim Speichern eines neuen Produkts
+    if (title.textContent.includes('Add new Product')) {
+      fetch('/product_management', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({
+          'product_name': form.product_name.value
+        })
+      })
+      .then(response => {
+        if (response.ok) {
+          // Seite neu laden, um das neue Produkt anzuzeigen
+          window.location.reload();
+        } else {
+          return response.text().then(text => {
+            alert('Fehler: ' + text);
+          });
+        }
+      })
+      .catch(error => {
+        alert('Fehler: ' + error);
+      });
+    }
+    
     modal.classList.add("hidden");
   });
 });
 </script>
+

--- a/frontend/views/product_management.erb
+++ b/frontend/views/product_management.erb
@@ -14,6 +14,7 @@
   <ul class="product-list">
     <% @products.each do |p| %>
       <li class="product-item"
+          data-product_id="<%= p.product_id %>"
           data-product_name="<%= p.product_name %>"
           data-license_count="<%= p.licenses.count %>">
         <span class="product-name"><%= p.product_name %></span>
@@ -31,8 +32,12 @@
       <label>Name:</label>
       <input type="text" name="product_name" disabled>
 
-      <label>Number of sub licenses:</label>
-      <input type="number" name="license_count" disabled min="0">
+      <div id="license-info-container" style="display: none;">
+        <div class="info-field">
+          <span class="info-label">Number of sub licenses:</span>
+          <span id="license-count-display">0</span>
+        </div>
+      </div>
 
       <div class="modal-actions">
         <button type="button" id="edit-btn">Edit</button>
@@ -53,6 +58,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const saveBtn   = document.getElementById("save-btn");
   const deleteBtn = document.getElementById("delete-btn");
   const title     = document.getElementById("modal-title");
+  const licenseCountDisplay = document.getElementById("license-count-display");
 
   function openModal(mode, data={}) {
     title.textContent = mode === 'add'
@@ -60,16 +66,36 @@ document.addEventListener("DOMContentLoaded", () => {
       : 'Product configuration';
 
     // Felder mit Daten befüllen (oder leer lassen beim "add")
-    form.product_name.value  = data.product_name  || '';
-    form.license_count.value = data.license_count || 0;
+    form.product_name.value = data.product_name || '';
+    
+    // License info container nur im Edit-Modus anzeigen
+    const licenseInfoContainer = document.getElementById('license-info-container');
+    licenseInfoContainer.style.display = mode === 'edit' ? 'block' : 'none';
+    
+    // Lizenzanzahl als Text anzeigen
+    if (mode === 'edit') {
+      licenseCountDisplay.textContent = data.license_count || '0';
+    }
 
     // Inputs sperren
     [...form.elements].forEach(el => {
       if (['edit-btn','save-btn','delete-btn'].includes(el.id)) return;
-      el.disabled = mode === 'edit'; // Bei 'add' nicht sperren
+      el.disabled = mode === 'edit'; // Felder nur im Edit-Modus sperren
     });
+    
     saveBtn.disabled = mode === 'edit';
     deleteBtn.style.display = mode === 'edit' ? 'inline-block' : 'none';
+    
+    // Aktives Element markieren
+    document.querySelectorAll('.product-item').forEach(item => {
+      item.classList.remove('active');
+    });
+    
+    if (mode === 'edit') {
+      const clickedItem = document.querySelector(`[data-product_name="${data.product_name}"]`);
+      if (clickedItem) clickedItem.classList.add('active');
+    }
+    
     modal.classList.remove("hidden");
   }
 
@@ -82,23 +108,48 @@ document.addEventListener("DOMContentLoaded", () => {
   document.getElementById("add-product-btn")
     .addEventListener("click", () => openModal('add'));
 
-  closeBtn.addEventListener("click", () =>
-    modal.classList.add("hidden")
-  );
+  let isEditMode = false;
+
+  closeBtn.addEventListener("click", () => {
+    modal.classList.add("hidden");
+    // Zustand zurücksetzen
+    isEditMode = false;
+    editBtn.textContent = "Edit";
+    editBtn.classList.remove("cancel-btn");
+  });
+
 
   editBtn.addEventListener("click", () => {
-    [...form.elements].forEach(el => {
-      if (['edit-btn','delete-btn'].includes(el.id)) return;
-      el.disabled = false;
-    });
-    saveBtn.disabled = false;
-  });
-
-  deleteBtn.addEventListener("click", () => {
-    if (confirm("Soll dieses Product wirklich gelöscht werden?")) {
-      modal.classList.add("hidden");
+    isEditMode = !isEditMode;
+    
+    if (isEditMode) {
+      // Wechsel zu Edit-Modus
+      editBtn.textContent = "Abbrechen";
+      editBtn.classList.add("cancel-btn");
+      
+      // Felder entsperren
+      [...form.elements].forEach(el => {
+        if (['edit-btn','delete-btn'].includes(el.id)) return;
+        el.disabled = false;
+      });
+      saveBtn.disabled = false;
+    } else {
+      // Wechsel zurück zum Ansichtsmodus
+      editBtn.textContent = "Edit";
+      editBtn.classList.remove("cancel-btn");
+      
+      // Felder wieder sperren
+      [...form.elements].forEach(el => {
+        if (['edit-btn','delete-btn'].includes(el.id)) return;
+        el.disabled = true;
+      });
+      saveBtn.disabled = true;
     }
   });
+
+
+  deleteBtn.disabled = true;
+  deleteBtn.title = "Diese Funktion ist noch nicht implementiert";
 
   form.addEventListener("submit", e => {
     e.preventDefault();
@@ -119,8 +170,48 @@ document.addEventListener("DOMContentLoaded", () => {
           // Seite neu laden, um das neue Produkt anzuzeigen
           window.location.reload();
         } else {
-          return response.text().then(text => {
-            alert('Fehler: ' + text);
+          return response.text().then(errorText => {
+            const errorMessage = errorText.includes('Validation failed')
+              ? 'Der Produktname wird bereits verwendet. Bitte wähle einen anderen Namen.'
+              : 'Fehler beim Aktualisieren des Produkts: ' + errorText;
+
+            showErrorNotification(errorMessage);
+          });
+        }
+      })
+      .catch(error => {
+        alert('Fehler: ' + error);
+      });
+    } else {
+      // Update eines bestehenden Produkts
+      const productName = form.product_name.value;
+      const productId = document.querySelector('.product-item.active')?.dataset.product_id;
+      if (!productId || productId === 'undefined') {
+        alert('Fehler: Produkt-ID konnte nicht ermittelt werden');
+        return;
+      }
+      
+      fetch(`/product_management/${productId}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({
+          'product_name': productName
+        })
+      })
+      .then(response => {
+        if (response.ok) {
+          window.location.reload();
+        } else {
+          return response.text().then(errorText => {
+            // Fehlermeldung in einem benutzerfreundlichen Format anzeigen
+            const errorMessage = errorText.includes('Validation failed')
+              ? 'Der Produktname wird bereits verwendet. Bitte wähle einen anderen Namen.'
+              : 'Fehler beim Aktualisieren des Produkts: ' + errorText;
+
+            // Elegantere Anzeige statt alert
+            showErrorNotification(errorMessage);
           });
         }
       })
@@ -132,5 +223,48 @@ document.addEventListener("DOMContentLoaded", () => {
     modal.classList.add("hidden");
   });
 });
-</script>
 
+function showErrorNotification(message) {
+  // Bestehende Benachrichtigungen entfernen
+  const existingNotification = document.querySelector('.error-notification');
+  if (existingNotification) {
+    existingNotification.remove();
+  }
+  
+  // Neue Benachrichtigung erstellen
+  const notification = document.createElement('div');
+  notification.className = 'error-notification';
+  notification.innerHTML = `
+    <div class="notification-content">
+      <span class="notification-message">${message}</span>
+      <button class="notification-close">&times;</button>
+    </div>
+  `;
+  
+  // Styling für die Benachrichtigung
+  notification.style.position = 'fixed';
+  notification.style.top = '20px';
+  notification.style.right = '20px';
+  notification.style.backgroundColor = '#f8d7da';
+  notification.style.color = '#721c24';
+  notification.style.padding = '15px';
+  notification.style.borderRadius = '4px';
+  notification.style.boxShadow = '0 4px 8px rgba(0,0,0,0.1)';
+  notification.style.zIndex = '1000';
+  
+  // Benachrichtigung zum DOM hinzufügen
+  document.body.appendChild(notification);
+  
+  // Schließen-Button-Funktionalität
+  notification.querySelector('.notification-close').addEventListener('click', () => {
+    notification.remove();
+  });
+  
+  // Automatisches Ausblenden nach 5 Sekunden
+  setTimeout(() => {
+    notification.remove();
+  }, 5000);
+}
+
+
+</script>


### PR DESCRIPTION
**feat(product_management): Implement Create, Read, Update Functionality**

**Description:**

This Pull Request implements the core functionality for managing products (viewing, creating, editing) for administrators. It connects the frontend UI with the backend API, adds the necessary routes and UI enhancements, and ensures functionality through RSpec tests.

**Goals:**

*   Allow administrators to view the list of products.
*   Allow administrators to create new products.
*   Allow administrators to edit existing products (name only).
*   Ensure only administrators can access this functionality.
*   Provide an improved user experience for form validation feedback.

**Related Tickets:**

*   SCRUM-58
*   SCRUM-59

**Changes in Detail:**

**Backend (`backend/`):**

1.  **`app.rb`:**
    *   Enabled `method_override` to support PUT requests for updates.
2.  **`routes/admin_routes.rb`:**
    *   `GET /product_management`: Loads all products (`ProductDAO.all`) and renders the view.
    *   `POST /product_management`: Creates a new product, performs validation (duplicate name -> 422), and provides feedback.
    *   `PUT /product_management/:id`: Updates an existing product, performs validation (duplicate name -> 422), and provides feedback. Corrected error handling to specifically rescue `DAO::ValidationError` and return status 422 instead of 500.
3.  **`spec/routes/product_management_spec.rb`:**
    *   Added a new test file for product management routes.
    *   Implemented tests covering `GET`, `POST`, `PUT` routes, including:
        *   Success cases for displaying, creating, and updating.
        *   Validation checks for duplicate product names.
        *   Access control checks (Admin vs. regular user).
        *   Error handling for non-existent product updates.

**Frontend (`frontend/views/product_management.erb`):**

1.  **HTML:**
    *   Replaced the static product list with a dynamic list (`@products.each`).
    *   Added `data-product_id` attribute to list items for identification.
    *   Replaced the "Number of sub licenses" input field with a read-only text display (`#license-info-container`), visible only in edit mode.
2.  **JavaScript:**
    *   Implemented AJAX (`fetch`) for `POST` (create) and `PUT` (update) operations.
    *   The product modal now remains open on validation errors (status 422), allowing users to correct input without reopening. The modal closes only on success (2xx status).
    *   The "Edit" button now toggles to "Cancel" when in edit mode, with state reset on modal close.
    *   The "Delete" button is disabled and includes a tooltip indicating the feature is not yet implemented.
    *   Improved error display using `showErrorNotification`, providing specific messages for "already taken" errors.
    *   Ensured the modal's edit state (button text, field enablement) is maintained if an update fails due to validation.

**Known Exclusions:**

*   Product deletion functionality is not implemented; the corresponding button is disabled.

**How to Test:**

1.  Log in as an Admin user.
2.  Navigate to the "Product Management" page.
3.  Verify that the list of products is displayed correctly.
4.  Create a new product using the "+" button (success case).
5.  Attempt to create another product with the *same name* (error case: modal should stay open, error notification shown).
6.  Click on an existing product to open the modal.
7.  Click "Edit" (it should change to "Cancel"), modify the name, and click "Save" (success case).
8.  Attempt to change a product's name to one that *already exists* for another product (error case: modal stays open, error notification).
9.  Test the "Cancel" button (fields should become disabled again, button changes back to "Edit").
10. Verify the "Delete" button is disabled and shows the correct tooltip on hover.
11. Log in as a regular (non-admin) user and attempt to access the "Product Management" page or call the API endpoints directly (should result in a 403 Forbidden error).

