### PR TITLE
PR: Implement Account Lockout Feature (SCRUM-71)

### DIFF
--- a/backend/db/migrations/004_create_users.rb
+++ b/backend/db/migrations/004_create_users.rb
@@ -9,6 +9,8 @@ Sequel.migration do
       String :first_name
       String :last_name
       Boolean :is_active, null: false, default: true
+      Integer :failed_login_attempts, null: false, default: 0
+      DateTime :locked_at
 
       index :email
     end

--- a/backend/routes/auth_routes.rb
+++ b/backend/routes/auth_routes.rb
@@ -18,15 +18,34 @@ module AuthRoutes
 
       return render_login_error('Please fill in email and password.') if credentials_missing?(email, password)
 
+      user = UserDAO.find_by_email(email)
+
+      return render_login_error('Invalid email or password.') unless user&.is_active
+
+      if UserDAO.locked?(user)
+        return render_login_error('Your account has been blocked due to too many failed login attempts.')
+      end
+
+      authenticated_user = nil
       begin
-        user = AuthService.authenticate(email, password)
-        if user
-          establish_session(user)
+        authenticated_user = AuthService.authenticate(user, password)
+      rescue StandardError => e
+        return render_login_error("An error occurred: #{e.message}")
+      end
+
+      if authenticated_user
+        UserDAO.reset_lockout(user)
+        establish_session(authenticated_user)
+      else
+        updated_user = UserDAO.increment_failed_attempts(user)
+
+        if updated_user && updated_user.failed_login_attempts >= UserDAO::MAX_LOGIN_ATTEMPTS
+          UserDAO.lock_user(updated_user)
+          render_login_error("Incorrect password. Your account has been blocked due to too many failed attempts. Please try again in #{UserDAO::LOCKOUT_DURATION / 60} minutes.")
         else
           render_login_error('Invalid email or password.')
         end
-      rescue StandardError => e
-        render_login_error("An error occurred: #{e.message}")
+
       end
     end
 

--- a/backend/services/auth_service.rb
+++ b/backend/services/auth_service.rb
@@ -2,10 +2,7 @@
 
 # Service class which handles auth
 class AuthService
-  def self.authenticate(email, password)
-    return nil if credentials_invalid?(email, password)
-
-    user = UserDAO.find_by_email(email)
+  def self.authenticate(user, password)
     return user if user&.is_active && user.authenticate(password)
 
     nil

--- a/frontend/public/css/login.css
+++ b/frontend/public/css/login.css
@@ -1,97 +1,96 @@
 body {
-    font-family: Arial, sans-serif;
-    margin: 0;
-    padding: 0;
-    background-color: #ffffff;
-  }
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background-color: #ffffff;
+}
 
-  .login-container {
-    max-width: 360px;
-    margin: 80px auto;
-    padding: 20px;
-    border: 1px solid #e8e8e8;
-    border-radius: 8px;
-    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
-  }
+.login-container {
+  max-width: 360px;
+  margin: 80px auto;
+  padding: 20px;
+  border: 1px solid #e8e8e8;
+  border-radius: 8px;
+  box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+}
 
-  .logo {
-    text-align: center;
-    margin-bottom: 20px;
-    
-  }
+.logo {
+  text-align: center;
+  margin-bottom: 20px;
+}
 
-  .logo img {
-    width: 200px;
-    height: auto;
-    max-width: 100%;
-  }
+.logo img {
+  width: 200px;
+  height: auto;
+  max-width: 100%;
+}
 
-  .login-container h2 {
-    text-align: center;
-    margin-bottom: 20px;
-  }
+.login-container h2 {
+  text-align: center;
+  margin-bottom: 20px;
+}
 
-  .field {
-    margin-bottom: 15px;
-  }
+.field {
+  margin-bottom: 15px;
+}
 
-  .actions {
-    margin-top: 20px;
-  }
+.actions {
+  margin-top: 20px;
+}
 
-  label {
-    display: block;
-    margin-bottom: 5px;
-    font-weight: bold;
-  }
+label {
+  display: block;
+  margin-bottom: 5px;
+  font-weight: bold;
+}
 
-  input[type="email"],
-  input[type="password"],
-  input[type="text"] {
-    width: 100%;
-    padding: 8px;
-    box-sizing: border-box;
-  }
+input[type="email"],
+input[type="password"],
+input[type="text"] {
+  width: 100%;
+  padding: 8px;
+  box-sizing: border-box;
+}
 
-  .checkbox-remember {
-    display: inline-block;
-    margin-right: 5px;
-  }
+.checkbox-remember {
+  display: inline-block;
+  margin-right: 5px;
+}
 
-  .forgot-password-link {
-    display: inline-block;
-    margin-left: 8px;
-  }
+.forgot-password-link {
+  display: inline-block;
+  margin-left: 8px;
+}
 
-  .login-button {
-    width: 100%;
-    padding: 10px;
-    border: none;
-    background-color: #333;
-    color: #fff;
-    font-weight: bold;
-    cursor: pointer;
-    border-radius: 4px;
-  }
+.login-button {
+  width: 100%;
+  padding: 10px;
+  border: none;
+  background-color: #333;
+  color: #fff;
+  font-weight: bold;
+  cursor: pointer;
+  border-radius: 4px;
+}
 
-  .login-button:hover {
-    background-color: #555;
-  }
+.login-button:hover {
+  background-color: #555;
+}
 
-  .footer {
-    text-align: center;
-    margin-top: 15px;
-    font-size: 0.9em;
-  }
-  
-  .footer a {
-    color: #2c3e50;
-    text-decoration: none;
-  }
-  
-  .footer a:hover {
-    text-decoration: underline;
-  }
+.footer {
+  text-align: center;
+  margin-top: 15px;
+  font-size: 0.9em;
+}
+
+.footer a {
+  color: #2c3e50;
+  text-decoration: none;
+}
+
+.footer a:hover {
+  text-decoration: underline;
+}
 
 #form-error {
   display: none;

--- a/frontend/views/login.erb
+++ b/frontend/views/login.erb
@@ -1,4 +1,3 @@
-<!-- views/login.erb -->
 <!DOCTYPE html>
 <html>
   <head>
@@ -17,27 +16,19 @@
 
       <h2>Licentra</h2>
 
-      <!-- allgemeine Fehlermeldung -->
-      <div id="form-error" class="error" style="<%= @error ? 'display:block' : 'display:none' %>">
-        <%= @error || 'Bitte E‑Mail und Passwort ausfüllen.' %>
+      <div id="form-error" class="error" style="<%= @error ? 'display:block; color: #d8000c; background-color: #ffcdcd; border: 1px solid #d8000c; padding: 10px; margin-bottom: 15px; border-radius: 4px;' : 'display:none' %>">
+      <%= @error %>
       </div>
 
       <form id="login-form" action="/login" method="post">
         <div class="field">
-          <label for="email">Email</label>
-          <input type="email" id="email" name="email" placeholder="Value">
+          <label for="email">E-Mail</label>
+          <input type="email" id="email" name="email" required>
         </div>
 
         <div class="field">
-          <label for="password">Password</label>
-          <input type="password" id="password" name="password" placeholder="Value">
-        </div>
-
-        <div class="field">
-          <label class="checkbox-remember">
-            <input type="checkbox" id="remember_data" name="remember_data">
-            <span>remember data</span>
-          </label>
+          <label for="password">Passwort</label>
+          <input type="password" id="password" name="password" required>
         </div>
 
         <div class="actions">
@@ -55,4 +46,3 @@
     </div>
   </body>
 </html>
-


### PR DESCRIPTION
**Related Issue:** SCRUM-71

**Description:**

This Pull Request introduces an important security enhancement: **account lockout after multiple failed login attempts**.
If a user enters an incorrect password for their account a configurable number of times (currently set to 3 consecutive attempts), their account will be temporarily locked for 15 minutes to prevent brute-force attacks.

**Key Changes Implemented:**

*   **Database Schema:**
    *   Added `failed_login_attempts` (Integer, default 0) and `locked_at` (DateTime, nullable) columns to the `users` table. A Sequel migration is included.
*   **UserDAO Enhancements:**
    *   `increment_failed_attempts(user)`: Atomically increments the counter for failed login attempts for the given user.
    *   `lock_user(user)`: Sets the `locked_at` timestamp for the user, effectively locking the account.
    *   `reset_lockout(user)`: Resets `failed_login_attempts` to 0 and clears `locked_at` upon successful login.
    *   `is_locked?(user)`: Checks if the user's account is currently in a locked state.
    *   These DAO methods have been refactored for clarity and maintainability, utilizing a private `_perform_atomic_user_update` helper to reduce code duplication.
*   **Login Logic (`POST /login` in `AuthRoutes`):**
    *   Before attempting to authenticate, the system now checks if the user's account is already locked. If so, login is denied, and an appropriate message is displayed.
    *   On a failed password attempt for an existing user, `failed_login_attempts` is incremented.
    *   If the number of failed attempts reaches the `MAX_LOGIN_ATTEMPTS` threshold, the account is locked by calling `UserDAO.lock_user`.
    *   Upon a successful login, any existing lockout state (`failed_login_attempts` and `locked_at`) is cleared for the user.
*   **Client-Side Validation (Login Form):**
    *   Added the `required` HTML5 attribute to the email and password input fields on the login page. This provides basic, immediate feedback to the user in modern browsers if fields are left empty.
    *   **(Note: Server-side validation for empty fields remains the primary and essential check.)**

**How to Test:**

1.  Ensure the database migration has been run after `docker compose down -v` was executed.
2.  Attempt to log in with a valid user but an incorrect password.
    *   After the 1st and 2nd incorrect attempt, you should see a standard "invalid credentials" error.
    *   After the 3rd consecutive incorrect attempt, the error message should indicate that the account has been locked.
3.  Attempt to log in again with the (now locked) account using the correct password. The login should still fail, and the "account locked" message should persist.
4.  (Manual DB Check - Optional) Verify in the database that `failed_login_attempts` is 3 and `locked_at` is set for the user.
5.  Log in successfully with a different, unlocked user account.
6.  To test unlocking wait for 15 minutes and try again with the correct credentials
7.  Verify that submitting the login form with empty email or password fields is prevented by the browser (due to `required` attribute) and also handled gracefully by the server with an error message.