### PR TITLE
fix(admin license activate,SCRUM-133): fix critical bug

### DIFF
--- a/backend/services/license_service.rb
+++ b/backend/services/license_service.rb
@@ -21,13 +21,14 @@ class LicenseService
   def self.activate_license_for_user(assignment_id, user)
     _authorize_user_for_activation(user)
     assignment = _find_assignment_or_fail(assignment_id)
+    assignment_owner = UserDAO.find_by_id(assignment.user_id)
 
     license = _find_license_or_fail(assignment.license_id)
     _ensure_license_is_active_for_activation(license)
 
     DB.transaction do
       _ensure_license_has_available_seats(license)
-      _ensure_user_does_not_have_license_active(license, user)
+      _ensure_user_does_not_have_license_active(license, assignment_owner)
 
       LicenseAssignmentDAO.activate(assignment_id)
 


### PR DESCRIPTION
- this fix fixes a bug in admin license management for users
- the bug was, that whenever a license was activated it was checked if this license war already active for user
- this user was the input user of the caller, therefor in admin activation the admin
- so in the end, it always checked if the requested activation was already done for the admin, not for the assignment holder
- changed it, so that the assignment holder gets fetched just in time and the check is with its user