### PR TITLE
feat/SCRUM-132: Display Active User Licenses with Expiry Highlighting

### DIFF
--- a/backend/app.rb
+++ b/backend/app.rb
@@ -46,6 +46,7 @@ class LicentraApp < Sinatra::Base
   get '/' do
     require_login
     @user = current_user
+    @my_assignments = LicenseAssignmentDAO.find_active_for_user_with_details(@user.user_id)
     erb :home, layout: :'layouts/application'
   end
 

--- a/frontend/views/home.erb
+++ b/frontend/views/home.erb
@@ -15,7 +15,6 @@
           </p>
           <div class="row row-cols-1 row-cols-md-2 g-4">
 
-            <%# --- NORMAl USER CARDS (IMMER) --- %>
             <!-- My Profile -->
             <div class="col">
               <div class="card home-nav-card h-100" data-target="/profile" style="cursor:pointer;">
@@ -101,14 +100,64 @@
                 <div class="card home-nav-card h-100 border-warning border-2" data-target="/admin/settings" style="cursor:pointer;">
                   <div class="card-body d-flex flex-column align-items-start">
                     <i class="fas fa-cogs fa-2x text-warning mb-3"></i>
-                      <h5 class="card-title">SMTP Settings</h5>
-                      <p class="card-text flex-grow-1">Configure mail server settings (Admin only).</p>
-                      <button class="btn btn-warning mt-auto">Go to SMTP Settings</button>
+                    <h5 class="card-title">SMTP Settings</h5>
+                    <p class="card-text flex-grow-1">Configure mail server settings (Admin only).</p>
+                    <button class="btn btn-warning mt-auto">Go to SMTP Settings</button>
                   </div>
                 </div>
               </div>
             <% end %>
           </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <%# ----- LICENSE OVERVIEW SECTION ----- %>
+  <div class="row mt-5">
+    <div class="col-xl-8 mx-auto">
+      <div class="card shadow-sm rounded-3">
+        <div class="card-header bg-secondary text-white d-flex align-items-center">
+          <i class="fas fa-id-badge me-2"></i>
+          <h4 class="mb-0">Your Active Licenses</h4>
+        </div>
+        <div class="card-body">
+          <% if @my_assignments.nil? || @my_assignments.empty? %>
+            <div class="alert alert-info mb-0">
+              You do not have any active licenses currently.
+            </div>
+          <% else %>
+            <div class="row row-cols-1 g-4">
+              <% @my_assignments.each do |assignment| %>
+                <% expire_date = assignment.license&.expire_date %>
+                <% days_left = (expire_date && expire_date.to_date > Date.today) ? (expire_date.to_date - Date.today).to_i : nil %>
+                <% is_expiring = days_left && days_left <= 30 && days_left >= 0 %>
+                <div class="col">
+                  <div class="card license-card h-100
+                    <%= 'border border-danger border-2' if is_expiring %>
+                    <%= 'bg-light' if is_expiring %>">
+                    <div class="card-header d-flex justify-content-between align-items-center">
+                      <span>
+                        <i class="fas fa-key me-1"></i>
+                        <strong>
+                          <%= assignment.license&.license_name || assignment.license&.product&.product_name || "Unnamed License" %>
+                        </strong>
+                        <% if is_expiring %>
+                          <span class="badge bg-danger ms-2">
+                            <i class="fas fa-exclamation-triangle"></i>
+                            expires in <%= days_left %> days
+                          </span>
+                        <% end %>
+                      </span>
+                      <span class="badge bg-<%= assignment.is_active ? 'success' : 'danger' %>">
+                        <%= assignment.is_active ? 'Active' : 'Inactive' %>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This pull request adds a new section to home.erb that displays all active licenses assigned to the logged-in user, as part of SCRUM-132. Licenses that are set to expire within the next 30 days are visually highlighted to draw the user's attention.

This enhancement improves transparency and helps users stay informed about upcoming license expirations.